### PR TITLE
grammar corrections

### DIFF
--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -130,14 +130,13 @@ second_terminal_character = {
 integer = @{ ASCII_NONZERO_DIGIT ~ ASCII_DIGIT* }
 
 // See 4.14
-meta_identifier = @{ ASCII_ALPHA ~ (meta_identifier_character)* }
+meta_identifier = @{ ASCII_ALPHA ~ (space_character? ~ meta_identifier_character)* }
 
 // See 4.15
 meta_identifier_character = _{
     ASCII_ALPHA
     | ASCII_DIGIT
     | "_"
-    | " "
 }
 
 // See 4.19

--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -59,11 +59,6 @@ terminator_symbol = {
     | "."
 }
 
-// see 7.5
-other_character = {
-    " " | ":" | "+" | "_" | "%" | "@" | "&" | "#" | "$" | "<" | ">" | "\\" | "ˆ" | "‘" | "˜"
-}
-
 // see 7.6
 space_character = { " " }
 
@@ -82,7 +77,8 @@ vertical_tabulation_character = {
 // ISO 6429 character Form Feed
 form_feed = { "\\f" }
 
-terminal_character = {
+// this is a helper to properly defined other_character for all of Unicode
+other_terminal_character = {
     ASCII_ALPHA
     | ASCII_DIGIT
     | concatenate_symbol
@@ -102,6 +98,15 @@ terminal_character = {
     | start_option_symbol
     | start_repeat_symbol
     | terminator_symbol
+}
+
+// see 7.5
+other_character = {
+    !other_terminal_character ~ ANY
+}
+
+terminal_character = {
+    other_terminal_character
     | other_character
 }
 

--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -132,6 +132,7 @@ meta_identifier_character = _{
     ASCII_ALPHA
     | ASCII_DIGIT
     | "_"
+    | " "
 }
 
 // See 4.19
@@ -160,6 +161,11 @@ special_sequence_character = {
     | start_repeat_symbol
     | terminator_symbol
     | other_character
+}
+
+// See 4.21
+empty_sequence = {
+    ""
 }
 
 // The final part of the syntax defines the
@@ -205,6 +211,7 @@ syntactic_primary = {
     | meta_identifier
     | terminal_string
     | special_sequence
+    | empty_sequence
 }
 
 // See 4.11


### PR DESCRIPTION
This corrects some mistakes in the grammar:
- Even though § 4.14, 4.15 do not mention it, the examples make it clear that a meta-identifier can contain spaces.
- Allow for a syntactic-primary to be an empty-sequence, as stated in § 4.10 (g). This now correctly allows the syntax used in an example in § 5.8 : `{"A"}-`
- Although § 7.5 states "in the ISO/IEC 646:1991 character set", it makes more sense to allow full Unicode in a Rust environment. Thus the definition for other-character was changed to allow any Unicode character that is not an other terminal-character. (See also added comments in the grammar)