### PR TITLE
more grammar corrections, optimisations

### DIFF
--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -196,15 +196,15 @@ syntactic_term = {
     syntactic_factor ~ (except_symbol ~ syntactic_exception)?
 }
 
-// See 4.7
-// NOTE: syntactic_exception must be checked ourselves.
-syntactic_exception = {
-    (integer ~ repetition_symbol)? ~ syntactic_primary
-}
-
 // See 4.8
 syntactic_factor = {
     (integer ~ repetition_symbol)? ~ syntactic_primary
+}
+
+// See 4.7
+// NOTE: syntactic_exception must be checked ourselves.
+syntactic_exception = {
+    syntactic_factor
 }
 
 // See 4.10

--- a/src/ebnf.pest
+++ b/src/ebnf.pest
@@ -40,7 +40,7 @@ end_repeat_symbol = {
     | ":)"
 }
 except_symbol = { "-" }
-first_quote_symbol = { "’" }
+first_quote_symbol = { "'" }
 repetition_symbol = { "*" }
 second_quote_symbol = { "\"" }
 special_sequence_symbol = { "?" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,14 @@ pub enum SyntacticPrimary {
     TerminalString(String),
 }
 
+fn extract_content(pair: Pair<Rule>) -> String {
+    // remove the first and last character
+    let mut chars = pair.as_str().chars();
+    chars.next();
+    chars.next_back();
+    chars.collect::<String>()
+}
+
 impl EBNFParser {
     pub fn parse_meta_identifier(pair: Pair<Rule>) -> Option<String> {
         match pair.as_rule() {
@@ -279,8 +287,8 @@ pairs:
             Rule::meta_identifier => {
                 SyntacticPrimary::MetaIdentifier(EBNFParser::parse_meta_identifier(pair)?)
             }
-            Rule::terminal_string => SyntacticPrimary::TerminalString(String::from(pair.as_str())),
-            Rule::special_sequence => SyntacticPrimary::Special(String::from(pair.as_str())),
+            Rule::terminal_string => SyntacticPrimary::TerminalString(extract_content(pair)),
+            Rule::special_sequence => SyntacticPrimary::Special(extract_content(pair)),
             _ => panic!(
                 r#"
             parse_syntactic_primary is unable to match any of the expected enum.
@@ -338,9 +346,7 @@ mod tests {
                             terms: vec![SyntacticTerm {
                                 factor: SyntacticFactor {
                                     repetition: 1,
-                                    primary: SyntacticPrimary::TerminalString(
-                                        r#""abcde""#.to_string()
-                                    )
+                                    primary: SyntacticPrimary::TerminalString("abcde".to_string())
                                 },
                                 except: None
                             }]
@@ -367,7 +373,7 @@ mod tests {
                                     factor: SyntacticFactor {
                                         repetition: 1,
                                         primary: SyntacticPrimary::TerminalString(
-                                            r#""abcde""#.to_string()
+                                            "abcde".to_string()
                                         )
                                     },
                                     except: None
@@ -377,7 +383,7 @@ mod tests {
                     },
                     except: Some(SyntacticFactor {
                         repetition: 1,
-                        primary: SyntacticPrimary::TerminalString(r#""xyz""#.to_string()),
+                        primary: SyntacticPrimary::TerminalString("xyz".to_string()),
                     })
                 })
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
     fn parse_symbols() -> Result<(), Box<dyn std::error::Error>> {
         EBNFParser::parse(Rule::defining_symbol, r#"="#)?;
         EBNFParser::parse(Rule::definition_separator_symbol, r#"|"#)?;
-        EBNFParser::parse(Rule::first_quote_symbol, r#"’"#)?;
+        EBNFParser::parse(Rule::first_quote_symbol, r#"'"#)?;
         EBNFParser::parse(Rule::second_quote_symbol, r#"""#)?;
         EBNFParser::parse(Rule::repetition_symbol, r#"*"#)?;
         Ok(())
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn parse_terminal_string() -> Result<(), Box<dyn std::error::Error>> {
         EBNFParser::parse(Rule::terminal_string, r#""b \r a \n d""#)?;
-        EBNFParser::parse(Rule::terminal_string, r#"’a’"#)?;
+        EBNFParser::parse(Rule::terminal_string, r#"'a'"#)?;
         Ok(())
     }
 
@@ -469,44 +469,44 @@ mod tests {
             and gap-separator in Extended BNF.
             *)
             (* see 7.2 *) 
-            letter = ’a’ | ’b’ | ’c’ | ’d’ | ’e’ | ’f’ | ’g’ | ’h’
-            | ’i’ | ’j’ | ’k’ | ’l’ | ’m’ | ’n’ | ’o’ | ’p’
-            | ’q’ | ’r’ | ’s’ | ’t’ | ’u’ | ’v’ | ’w’ | ’x’
-            | ’y’ | ’z’
-            | ’A’ | ’B’ | ’C’ | ’D’ | ’E’ | ’F’ | ’G’ | ’H’
-            | ’I’ | ’J’ | ’K’ | ’L’ | ’M’ | ’N’ | ’O’ | ’P’
-            | ’Q’ | ’R’ | ’S’ | ’T’ | ’U’ | ’V’ | ’W’ | ’X’
-            | ’Y’ | ’Z’;
+            letter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'
+            | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p'
+            | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x'
+            | 'y' | 'z'
+            | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H'
+            | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P'
+            | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X'
+            | 'Y' | 'Z';
             (* see 7.2 *) decimal_digit
-            = ’0’ | ’1’ | ’2’ | ’3’ | ’4’ | ’5’ | ’6’ | ’7’
-            | ’8’ | ’9’;
+            = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7'
+            | '8' | '9';
             (*
             The representation of the following
             terminal-characters is defined in clauses 7.3,
             7.4 and tables 1, 2.
             *)
-            concatenate_symbol = ’,’;
-            defining_symbol = ’=’;
-            definition_separator_symbol = ’|’ | ’//’ | ’!’;
-            end_comment_symbol = ’*)’;
-            end_group_symbol = ’)’;
-            end_option_symbol = ’]’ | ’/)’;
-            end_repeat_symbol = ’}’ | ’:)’;
-            except_symbol = ’-’;
-            first_quote_symbol = "’";
-            repetition_symbol = ’*’;
-            second_quote_symbol = ’"’;
-            special_sequence_symbol = ’?’;
-            start_comment_symbol = ’(*’;
-            start_group_symbol = ’(’;
-            start_option_symbol = ’[’ | ’(//’;
-            start_repeat_symbol = ’{’ | ’(:’;
-            terminator_symbol = ’;’ | ’.’;
+            concatenate_symbol = ',';
+            defining_symbol = '=';
+            definition_separator_symbol = '|' | '//' | '!';
+            end_comment_symbol = '*)';
+            end_group_symbol = ')';
+            end_option_symbol = ']' | '/)';
+            end_repeat_symbol = '}' | ':)';
+            except_symbol = '-';
+            first_quote_symbol = "'";
+            repetition_symbol = '*';
+            second_quote_symbol = '"';
+            special_sequence_symbol = '?';
+            start_comment_symbol = '(*';
+            start_group_symbol = '(';
+            start_option_symbol = '[' | '(//';
+            start_repeat_symbol = '{' | '(:';
+            terminator_symbol = ';' | '.';
             (* see 7.5 *) other_character
-            = ’ ’ | ’:’ | ’+’ | ’_’ | ’%’ | ’@’
-            | ’&’ | ’#’ | ’$’ | ’<’ | ’>’ | ’\’
-            | ’ˆ’ | ’‘’ | ’˜’;
-            (* see 7.6 *) space_character = ’ ’;                
+            = ' ' | ':' | '+' | '_' | '%' | '@'
+            | '&' | '#' | '$' | '<' | '>' | '\'
+            | 'ˆ' | '‘' | '˜';
+            (* see 7.6 *) space_character = ' ';
             "#,
         )?.next() {
             // TODO: Complete this :)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,7 @@ impl EBNFParser {
     }
 
     fn parse_definition_list_in_sequence(pair: Pairs<Rule>) -> DefinitionList {
-        let definition_list = pair.skip(1).next().unwrap();
+        let definition_list = pair.nth(1).unwrap();
         assert_eq!(definition_list.as_rule(), Rule::definition_list);
 
         EBNFParser::parse_definition_list(definition_list)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,8 @@ pub struct Syntax {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct MetaIdentifier {
-    value: String,
-}
-
-#[derive(Debug, Eq, PartialEq)]
 pub struct SyntaxRule {
-    identifier: MetaIdentifier,
+    identifier: String,
     definitions: DefinitionList,
 }
 
@@ -58,16 +53,14 @@ pub enum SyntacticPrimary {
     // By definition, we have no idea how to parse special sequences.
     // just pass the string to the user.
     Special(String),
-    MetaIdentifier(MetaIdentifier),
+    MetaIdentifier(String),
     TerminalString(String),
 }
 
 impl EBNFParser {
-    pub fn parse_meta_identifier(pair: Pair<Rule>) -> Option<MetaIdentifier> {
+    pub fn parse_meta_identifier(pair: Pair<Rule>) -> Option<String> {
         match pair.as_rule() {
-            Rule::meta_identifier => Some(MetaIdentifier {
-                value: String::from(pair.as_str()),
-            }),
+            Rule::meta_identifier => Some(pair.as_str().to_string()),
             _ => None,
         }
     }
@@ -313,9 +306,7 @@ mod tests {
         if let Some(pair) = EBNFParser::parse(Rule::meta_identifier, r#"letter"#)?.next() {
             assert_eq!(
                 EBNFParser::parse_meta_identifier(pair),
-                Some(MetaIdentifier {
-                    value: "letter".to_string()
-                })
+                Some("letter".to_string())
             );
         };
 
@@ -416,9 +407,7 @@ mod tests {
             assert_eq!(
                 EBNFParser::parse_syntax_rule(pair),
                 Some(SyntaxRule {
-                    identifier: MetaIdentifier {
-                        value: "letter".to_string()
-                    },
+                    identifier: "letter".to_string(),
                     definitions: EBNFParser::parse_definition_list(
                         EBNFParser::parse(Rule::definition_list, r#""a" | "b""#)?
                             .next()
@@ -440,9 +429,7 @@ mod tests {
                 EBNFParser::parse_syntax(pair),
                 Some(Syntax {
                     rules: vec![SyntaxRule {
-                        identifier: MetaIdentifier {
-                            value: "letter".to_string()
-                        },
+                        identifier: "letter".to_string(),
                         definitions: EBNFParser::parse_definition_list(
                             EBNFParser::parse(Rule::definition_list, r#""a" | "b""#)?
                                 .next()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@ impl EBNFParser {
             rules: pair
                 // TODO: We should really check that EOI only exists in the beginning.
                 .filter(|rule| rule.as_rule() != Rule::EOI)
-                .map(|rule| EBNFParser::parse_syntax_rule(rule))
+                .map(EBNFParser::parse_syntax_rule)
                 .collect::<Option<Vec<SyntaxRule>>>()?,
         })
     }
@@ -132,7 +132,7 @@ impl EBNFParser {
         Some(DefinitionList {
             list: pair
                 .step_by(2)
-                .map(|definition_list| EBNFParser::parse_single_definition(definition_list))
+                .map(EBNFParser::parse_single_definition)
                 .collect::<Option<Vec<SingleDefinition>>>()?,
         })
     }
@@ -142,7 +142,7 @@ impl EBNFParser {
         Some(SingleDefinition {
             terms: pair
                 .step_by(2)
-                .map(|syntactic_term| EBNFParser::parse_syntactic_term(syntactic_term))
+                .map(EBNFParser::parse_syntactic_term)
                 .collect::<Option<Vec<SyntacticTerm>>>()?,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ impl EBNFParser {
         let pair = pair.into_inner();
         Some(DefinitionList {
             list: pair
+                // skipping over definition_separator_symbol's
                 .step_by(2)
                 .map(EBNFParser::parse_single_definition)
                 .collect::<Option<Vec<SingleDefinition>>>()?,
@@ -137,6 +138,7 @@ impl EBNFParser {
         let pair = pair.into_inner();
         Some(SingleDefinition {
             terms: pair
+                // skipping over concatenate_symbol's
                 .step_by(2)
                 .map(EBNFParser::parse_syntactic_term)
                 .collect::<Option<Vec<SyntacticTerm>>>()?,
@@ -319,18 +321,18 @@ mod tests {
 
     #[test]
     fn parse_symbols() -> Result<(), Box<dyn std::error::Error>> {
-        EBNFParser::parse(Rule::defining_symbol, r#"="#)?;
-        EBNFParser::parse(Rule::definition_separator_symbol, r#"|"#)?;
-        EBNFParser::parse(Rule::first_quote_symbol, r#"'"#)?;
+        EBNFParser::parse(Rule::defining_symbol, "=")?;
+        EBNFParser::parse(Rule::definition_separator_symbol, "|")?;
+        EBNFParser::parse(Rule::first_quote_symbol, "'")?;
         EBNFParser::parse(Rule::second_quote_symbol, r#"""#)?;
-        EBNFParser::parse(Rule::repetition_symbol, r#"*"#)?;
+        EBNFParser::parse(Rule::repetition_symbol, "*")?;
         Ok(())
     }
 
     #[test]
     fn parse_terminal_string() -> Result<(), Box<dyn std::error::Error>> {
         EBNFParser::parse(Rule::terminal_string, r#""b \r a \n d""#)?;
-        EBNFParser::parse(Rule::terminal_string, r#"'a'"#)?;
+        EBNFParser::parse(Rule::terminal_string, "'a'")?;
         Ok(())
     }
 
@@ -354,7 +356,7 @@ mod tests {
                     })
                 })
             )
-        };
+        }
         Ok(())
     }
 
@@ -387,7 +389,7 @@ mod tests {
                     })
                 })
             )
-        };
+        }
         Ok(())
     }
 
@@ -400,7 +402,7 @@ mod tests {
         .next()
         {
             EBNFParser::parse_definition_list(pair);
-        };
+        }
         Ok(())
     }
 
@@ -419,7 +421,7 @@ mod tests {
                     .unwrap()
                 })
             );
-        };
+        }
         if let Some(pair) = EBNFParser::parse(
             Rule::syntax,
             r#"
@@ -442,7 +444,7 @@ mod tests {
                     }]
                 })
             );
-        };
+        }
         Ok(())
     }
 
@@ -517,7 +519,7 @@ mod tests {
         )?.next() {
             // TODO: Complete this :)
             // assert_eq!(EBNFParser::parse_syntax(pair), None);
-        };
+        }
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub enum SyntacticPrimary {
     Special(String),
     MetaIdentifier(String),
     TerminalString(String),
+    Empty,
 }
 
 fn extract_content(pair: Pair<Rule>) -> String {
@@ -242,6 +243,7 @@ impl EBNFParser {
             }
             Rule::terminal_string => SyntacticPrimary::TerminalString(extract_content(pair)),
             Rule::special_sequence => SyntacticPrimary::Special(extract_content(pair)),
+            Rule::empty_sequence => SyntacticPrimary::Empty,
             _ => panic!(
                 r#"
             parse_syntactic_primary is unable to match any of the expected enum.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,14 +29,9 @@ pub struct SingleDefinition {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct SyntacticException {
-    content: String,
-}
-
-#[derive(Debug, Eq, PartialEq)]
 pub struct SyntacticTerm {
     factor: SyntacticFactor,
-    except: Option<SyntacticException>,
+    except: Option<SyntacticFactor>,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -140,11 +135,12 @@ impl EBNFParser {
         })
     }
 
-    pub fn parse_syntactic_exception(pair: Pair<Rule>) -> Option<SyntacticException> {
-        let pair = pair.into_inner();
-        Some(SyntacticException {
-            content: String::from(pair.as_str()),
-        })
+    pub fn parse_syntactic_exception(pair: Pair<Rule>) -> Option<SyntacticFactor> {
+        let pair = pair.into_inner().next().unwrap();
+        let factor = Self::parse_syntactic_factor(pair)?;
+        // FIXME: check restriction from § 4.7:
+        // factor must be non-recursive
+        Some(factor)
     }
 
     pub fn parse_syntactic_term(pair: Pair<Rule>) -> Option<SyntacticTerm> {
@@ -379,8 +375,9 @@ mod tests {
                             }]
                         })
                     },
-                    except: Some(SyntacticException {
-                        content: r#""xyz""#.to_string()
+                    except: Some(SyntacticFactor {
+                        repetition: 1,
+                        primary: SyntacticPrimary::TerminalString(r#""xyz""#.to_string()),
                     })
                 })
             )


### PR DESCRIPTION
### grammar corrections
- for terminal-strings and special-sequences, only the content is stored, i.e. for terminal-strings, the surrounding quotes are not stored, and for special-sequences the surrounding question marks are not stored. (8d9e490)
- the first-quote-symbol has been changed from `U+2019 Right Single Quotation Mark` to `U+0027 Apostrophe`. § 7.3 Table 1 calls for "apostrophe", also the new symbol is more frequently available on keyboards. (c54e837)
- the `SyntacticException` struct is replaced with `SyntacticFactor` and syntactic-exceptions are stored correctly (before they were stored as the original EBNF text, effectively forgetting all parsing done to them). (717947a)
### optimisations
- implement 3 cargo clippy recommendations: removed unnecessary closures (a6f7284)
- the `MetaIdentifier` struct is replaced with just `String`, simplifying the types (a7c37cd)
- added a few comments, removed unnecessary raw string literals and semicolons (d5a5ee9)
- simplified the checks if the correct rules were matched and found a bug (f576a4d)