### PR TITLE
fix impl_from_str macro, remove unnecessary code

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,24 +1,29 @@
 use crate::parser::Rule;
+use std::{
+    convert::From,
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
 
 #[derive(Debug)]
 pub enum EBNFError {
     UnexpectedRules(Vec<(Rule, String)>),
     InsufficientTokens(Vec<Option<Rule>>),
     NoTokens,
-    Pest(Box<dyn std::error::Error>),
+    Pest(Box<dyn Error>),
 }
 
-impl std::error::Error for EBNFError {}
+impl Error for EBNFError {}
 
-impl std::fmt::Display for EBNFError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for EBNFError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{:#?}", self)
     }
 }
 
 macro_rules! impl_error {
     ($ty:ty) => {
-        impl std::convert::From<$ty> for EBNFError {
+        impl From<$ty> for EBNFError {
             fn from(error: $ty) -> Self {
                 EBNFError::Pest(Box::new(error))
             }
@@ -29,4 +34,4 @@ macro_rules! impl_error {
 impl_error!(pest::error::Error<Rule>);
 impl_error!(std::num::ParseIntError);
 
-pub type EBNFResult<T> = std::result::Result<T, EBNFError>;
+pub type EBNFResult<T> = Result<T, EBNFError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,17 +21,10 @@ impl Display for EBNFError {
     }
 }
 
-macro_rules! impl_error {
-    ($ty:ty) => {
-        impl From<$ty> for EBNFError {
-            fn from(error: $ty) -> Self {
-                EBNFError::Pest(Box::new(error))
-            }
-        }
-    };
+impl From<pest::error::Error<Rule>> for EBNFError {
+    fn from(error: pest::error::Error<Rule>) -> Self {
+        EBNFError::Pest(Box::new(error))
+    }
 }
-
-impl_error!(pest::error::Error<Rule>);
-impl_error!(std::num::ParseIntError);
 
 pub type EBNFResult<T> = Result<T, EBNFError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
-use crate::parser::Rrule;
+use crate::parser::Rule;
 
 #[derive(Debug)]
 pub enum EBNFError {
-    UnexpectedRules(Vec<(Rrule, String)>),
-    InsufficientTokens(Vec<Option<Rrule>>),
+    UnexpectedRules(Vec<(Rule, String)>),
+    InsufficientTokens(Vec<Option<Rule>>),
     NoTokens,
     Pest(Box<dyn std::error::Error>),
 }
@@ -26,7 +26,7 @@ macro_rules! impl_error {
     };
 }
 
-impl_error!(pest::error::Error<Rrule>);
+impl_error!(pest::error::Error<Rule>);
 impl_error!(std::num::ParseIntError);
 
 pub type EBNFResult<T> = std::result::Result<T, EBNFError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,5 @@ pub use parser::{
 };
 
 pub fn parse(raw: &str) -> error::EBNFResult<parser::Syntax> {
-    parser::InnerParser::new(raw)
+    raw.parse::<Syntax>()
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,12 +1,7 @@
 use crate::error::{EBNFError, EBNFResult};
 use pest::iterators::{Pair, Pairs};
-#[allow(unused_imports)]
 use pest::Parser;
 use std::{convert::TryFrom, hash::Hash};
-
-trait FromRule: Sized {
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<Self>;
-}
 
 #[derive(Parser)]
 #[grammar = "./ebnf.pest"]
@@ -25,7 +20,7 @@ pub struct Syntax {
     rules: Vec<SyntaxRule>,
 }
 
-macro_rules! impl_form_str {
+macro_rules! impl_from_str {
     ($ty:ty, $val:expr) => {
         impl std::str::FromStr for $ty {
             type Err = EBNFError;
@@ -42,7 +37,7 @@ macro_rules! impl_form_str {
     };
 }
 
-impl_form_str!(Syntax, Rule::syntax);
+impl_from_str!(Syntax, Rule::syntax);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for Syntax {
     type Error = EBNFError;
@@ -62,7 +57,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for Syntax {
 #[derive(Debug, Eq, PartialEq)]
 pub struct MetaIdentifier(String);
 
-impl_form_str!(MetaIdentifier, Rule::meta_identifier);
+impl_from_str!(MetaIdentifier, Rule::meta_identifier);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for MetaIdentifier {
     type Error = EBNFError;
@@ -83,7 +78,7 @@ pub struct SyntaxRule {
     definitions: DefinitionList,
 }
 
-impl_form_str!(SyntaxRule, Rule::syntax_rule);
+impl_from_str!(SyntaxRule, Rule::syntax_rule);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SyntaxRule {
     type Error = EBNFError;
@@ -130,7 +125,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for SyntaxRule {
 #[derive(Debug, Eq, PartialEq)]
 pub struct DefinitionList(Vec<SingleDefinition>);
 
-impl_form_str!(DefinitionList, Rule::definition_list);
+impl_from_str!(DefinitionList, Rule::definition_list);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for DefinitionList {
     type Error = EBNFError;
@@ -147,7 +142,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for DefinitionList {
 #[derive(Debug, Eq, PartialEq)]
 pub struct SingleDefinition(Vec<SyntacticTerm>);
 
-impl_form_str!(SingleDefinition, Rule::single_definition);
+impl_from_str!(SingleDefinition, Rule::single_definition);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SingleDefinition {
     type Error = EBNFError;
@@ -164,7 +159,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for SingleDefinition {
 #[derive(Debug, Eq, PartialEq)]
 pub struct SyntacticException(String);
 
-impl_form_str!(SyntacticException, Rule::syntactic_expression);
+impl_from_str!(SyntacticException, Rule::syntactic_expression);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticException {
     type Error = EBNFError;
@@ -180,7 +175,7 @@ pub struct SyntacticTerm {
     except: Option<SyntacticException>,
 }
 
-impl_form_str!(SyntacticTerm, Rule::syntactic_term);
+impl_from_str!(SyntacticTerm, Rule::syntactic_term);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticTerm {
     type Error = EBNFError;
@@ -224,7 +219,7 @@ pub struct SyntacticFactor {
     primary: SyntacticPrimary,
 }
 
-impl_form_str!(SyntacticFactor, Rule::syntactic_factor);
+impl_from_str!(SyntacticFactor, Rule::syntactic_factor);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticFactor {
     type Error = EBNFError;
@@ -279,7 +274,7 @@ pub enum SyntacticPrimary {
     TerminalString(String),
 }
 
-impl_form_str!(SyntacticPrimary, Rule::syntactic_primary);
+impl_from_str!(SyntacticPrimary, Rule::syntactic_primary);
 
 impl SyntacticPrimary {
     fn parse_definition_list_in_sequence(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,9 +18,8 @@ macro_rules! impl_from_str {
             type Err = EBNFError;
 
             fn from_str(raw: &str) -> Result<Self, Self::Err> {
-                if let Some(pair) = InnerParser::parse(Rule::syntax, raw)?.next() {
-                    let syntax = Self::try_from(pair)?;
-                    Ok(syntax)
+                if let Some(pair) = InnerParser::parse($val, raw)?.next() {
+                    Self::try_from(pair)
                 } else {
                     Err(EBNFError::NoTokens)
                 }
@@ -151,7 +150,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for SingleDefinition {
 #[derive(Debug, Eq, PartialEq)]
 pub struct SyntacticException(String);
 
-impl_from_str!(SyntacticException, Rule::syntactic_expression);
+impl_from_str!(SyntacticException, Rule::syntactic_exception);
 
 impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticException {
     type Error = EBNFError;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,8 +12,6 @@ trait FromRule: Sized {
 #[grammar = "./ebnf.pest"]
 pub struct InnerParser;
 
-pub type Rrule = Rule;
-
 impl InnerParser {
     pub fn new(raw: &str) -> EBNFResult<Syntax> {
         let pair = InnerParser::parse(Rule::syntax, raw)?.next().unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -224,7 +224,8 @@ impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticFactor {
             ) {
                 (Rule::integer, Rule::repetition_symbol, Rule::syntactic_primary) => {
                     Ok(SyntacticFactor {
-                        repetition: integer.as_str().parse::<usize>()?,
+                        // can unwrap here because the grammar already ensures this is a number
+                        repetition: integer.as_str().parse::<usize>().unwrap(),
                         primary: SyntacticPrimary::try_from(syntactic_primary)?,
                     })
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,15 +5,7 @@ use std::{convert::TryFrom, hash::Hash};
 
 #[derive(Parser)]
 #[grammar = "./ebnf.pest"]
-pub struct InnerParser;
-
-impl InnerParser {
-    pub fn new(raw: &str) -> EBNFResult<Syntax> {
-        let pair = InnerParser::parse(Rule::syntax, raw)?.next().unwrap();
-        let syntax = Syntax::try_from(pair)?;
-        Ok(syntax)
-    }
-}
+pub(crate) struct InnerParser;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Syntax {
@@ -47,7 +39,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for Syntax {
             rules: inner
                 // TODO: We should really check that EOI only exists in the beginning.
                 .filter(|rule| rule.as_rule() != Rule::EOI)
-                .map(|rule| SyntaxRule::try_from(rule))
+                .map(SyntaxRule::try_from)
                 .collect::<EBNFResult<Vec<SyntaxRule>>>()?,
         };
         Ok(result)
@@ -133,7 +125,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for DefinitionList {
         let pair = pair.into_inner();
         Ok(DefinitionList(
             pair.step_by(2)
-                .map(|definition_list| SingleDefinition::try_from(definition_list))
+                .map(SingleDefinition::try_from)
                 .collect::<EBNFResult<Vec<SingleDefinition>>>()?,
         ))
     }
@@ -150,7 +142,7 @@ impl<'r> TryFrom<Pair<'r, Rule>> for SingleDefinition {
         let pair = pair.into_inner();
         Ok(SingleDefinition(
             pair.step_by(2)
-                .map(|syntactic_term| SyntacticTerm::try_from(syntactic_term))
+                .map(SyntacticTerm::try_from)
                 .collect::<EBNFResult<Vec<SyntacticTerm>>>()?,
         ))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,7 +5,7 @@ use std::{convert::TryFrom, hash::Hash};
 
 #[derive(Parser)]
 #[grammar = "./ebnf.pest"]
-pub(crate) struct InnerParser;
+struct InnerParser;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Syntax {


### PR DESCRIPTION
* remove the unnecessary `Rrule`, can just use `Rule` instead; also make `InnerParser` private (making them `pub` is a mistake because it should not be usable outside the crate as it only belongs to parsing internally)
* fix typo `impl_form_str` &rarr; `impl_from_str`
* the second macro parameter of `impl_from_str` was never used, was always trying to parse as `Rule::syntax`
* the repetition count parsing can be `unwrap`ed because the grammar does not allow for anything else, so the conversion from `std::num::ParseIntError` can be removed in `error.rs`
* add some `use` statements to the top of `error.rs` file to make code more concise

One question: Why did you make the `EBNFError` enum, I think it would be easier and better to just use `pest`s builtin error type. I noticed you reversed some of my previous changes and added back unnecessary tests from #3? If these were removed again, `EBNFError::UnexpectedRules` and `EBNFError::InsufficientTokens` should not be necessary.