### PR TITLE
Rewrite the entire library using nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ repository = "https://github.com/hbina/iso_14977"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nom = "7.1.0"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-### EBNF Parser Library (Hopefully ISO compliant!)
+### EBNF Parser Library (ISO 14977)
 
-This repository intends to be the ISO 14977 compliant EBNF parser library in Rust.
-Ironically, it uses pest to generate the syntax tree lol.
+EBNF (Extended Backus-Naur-Form) parser in Rust.
 
-I originally needed this to validate a DNS Preferred Name Syntax in RFC 1035.
-Unfortunately, I am unable to find any crates that can validate a string given some BNF rules.
-Additionally, the BNF provided in the RFC is not even standard EBNF --- which is kinda sad and dissappointing.
-Regardless, here it is, a hopefully ISO complaint implementation of it.
+Reference: https://www.cl.cam.ac.uk/~mgk25/iso-14977.pdf

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use crate::parser::Rule;
 use std::{
     convert::From,
     error::Error,
@@ -7,8 +6,6 @@ use std::{
 
 #[derive(Debug)]
 pub enum EBNFError {
-    UnexpectedRules(Vec<(Rule, String)>),
-    InsufficientTokens(Vec<Option<Rule>>),
     NoTokens,
     Pest(Box<dyn Error>),
 }
@@ -18,12 +15,6 @@ impl Error for EBNFError {}
 impl Display for EBNFError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{:#?}", self)
-    }
-}
-
-impl From<pest::error::Error<Rule>> for EBNFError {
-    fn from(error: pest::error::Error<Rule>) -> Self {
-        EBNFError::Pest(Box::new(error))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,3 @@ mod error;
 mod parser;
 
 pub use error::{EBNFError, EBNFResult};
-pub use parser::{
-    MetaIdentifier, SingleDefinition, SyntacticException, SyntacticFactor, SyntacticPrimary,
-    SyntacticTerm, Syntax, SyntaxRule,
-};
-
-pub fn parse(raw: &str) -> error::EBNFResult<parser::Syntax> {
-    raw.parse::<Syntax>()
-}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,618 +1,291 @@
-use crate::error::{EBNFError, EBNFResult};
-use pest::iterators::{Pair, Pairs};
-use pest::Parser;
-use std::{convert::TryFrom, hash::Hash};
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, take_while_m_n},
+    character::complete::one_of,
+    combinator::{consumed, map_res, not, recognize, verify},
+    multi::many0,
+    sequence::delimited,
+    sequence::tuple,
+    IResult as NomResult, Parser,
+};
 
-#[derive(Parser)]
-#[grammar = "./ebnf.pest"]
-struct InnerParser;
+macro_rules! ebnf_characters_functions {
+    ($func_name:ident, $out:ty, $pattern:expr) => {
+        fn $func_name(input: &str) -> NomResult<&str, $out> {
+            ($pattern)(input)
+        }
+    };
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct Syntax {
-    rules: Vec<SyntaxRule>,
-}
-
-macro_rules! impl_from_str {
-    ($ty:ty, $val:expr) => {
-        impl std::str::FromStr for $ty {
-            type Err = EBNFError;
-
-            fn from_str(raw: &str) -> Result<Self, Self::Err> {
-                if let Some(pair) = InnerParser::parse($val, raw)?.next() {
-                    Self::try_from(pair)
-                } else {
-                    Err(EBNFError::NoTokens)
-                }
-            }
+    ($func_name:ident, $out:ty, $($pattern:expr),+) => {
+        fn $func_name(input: &str) -> NomResult<&str, &str> {
+            alt((
+                $($pattern),+
+            ))(input)
         }
     };
 }
 
-impl_from_str!(Syntax, Rule::syntax);
+// The first part of the lexical syntax defines the characters in the 7-bit
+// character set (ISO/IEC 646:1991) that represent each terminal-character
+// and gap-separator in Extended BNF.
 
-impl<'r> TryFrom<Pair<'r, Rule>> for Syntax {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<'r, Rule>) -> EBNFResult<Syntax> {
-        let inner = pair.into_inner();
-        let result = Syntax {
-            rules: inner
-                // TODO: We should really check that EOI only exists in the beginning.
-                .filter(|rule| rule.as_rule() != Rule::EOI)
-                .map(SyntaxRule::try_from)
-                .collect::<EBNFResult<Vec<SyntaxRule>>>()?,
-        };
-        Ok(result)
+ebnf_characters_functions!(
+    is_letter,
+    &str,
+    recognize(one_of(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    ))
+);
+ebnf_characters_functions!(is_decimal_digit, &str, recognize(one_of("0123456789")));
+ebnf_characters_functions!(is_concatenate_symbol, &str, tag(","));
+ebnf_characters_functions!(is_defining_symbol, &str, tag("="));
+ebnf_characters_functions!(is_definition_separator, &str, recognize(one_of("|/!")));
+ebnf_characters_functions!(is_end_comment_symbol, &str, tag("*)"));
+ebnf_characters_functions!(is_end_group_symbol, &str, tag(")"));
+ebnf_characters_functions!(is_end_option_symbol, &str, tag("]"), tag("/)"));
+ebnf_characters_functions!(is_end_repeat_symbol, &str, tag("}"), tag(":)"));
+ebnf_characters_functions!(is_except_symbol, &str, tag("-"));
+ebnf_characters_functions!(is_first_quote_symbol, &str, tag("'"));
+ebnf_characters_functions!(is_repetition_symbol, &str, tag("*"));
+ebnf_characters_functions!(is_second_quote_symbol, &str, tag("\""));
+ebnf_characters_functions!(is_special_sequence_symbol, &str, tag("?"));
+ebnf_characters_functions!(is_start_comment_symbol, &str, tag("(*"));
+ebnf_characters_functions!(is_start_group_symbol, &str, tag("("));
+ebnf_characters_functions!(is_start_option_symbol, &str, tag("["), tag("(/"));
+ebnf_characters_functions!(is_start_repeat_symbol, &str, tag("{"), tag("(:"));
+ebnf_characters_functions!(is_terminator_symbol, &str, recognize(one_of(";.")));
+ebnf_characters_functions!(
+    is_other_character,
+    &str,
+    recognize(one_of(" :+_%@&#$<>\\^`~"))
+);
+ebnf_characters_functions!(is_space_character, &str, tag(" "));
+ebnf_characters_functions!(is_horizontal_tabulation_character, &str, tag("\t"));
+ebnf_characters_functions!(
+    is_new_line,
+    &str,
+    delimited(many0(tag("\r")), tag("\n"), many0(tag("\r")))
+);
+ebnf_characters_functions!(
+    is_vertical_tabulation_character,
+    &str,
+    tag("\\v"),
+    tag("\u{000B}")
+);
+ebnf_characters_functions!(is_form_feed, &str, tag("\\f"));
+
+// Second part fo the syntax defines the removal of unnecessary non-printing characters from a syntax
+
+ebnf_characters_functions!(
+    is_terminal_character,
+    &str,
+    alt((
+        is_letter,
+        is_decimal_digit,
+        is_concatenate_symbol,
+        is_defining_symbol,
+        is_definition_separator,
+        is_end_comment_symbol,
+        is_end_group_symbol,
+        is_end_option_symbol,
+        is_end_repeat_symbol,
+        is_except_symbol,
+        is_first_quote_symbol,
+        is_repetition_symbol,
+        is_second_quote_symbol,
+        is_special_sequence_symbol,
+        is_start_comment_symbol,
+        is_start_group_symbol,
+        is_start_option_symbol,
+        is_start_repeat_symbol,
+        is_terminator_symbol,
+        is_other_character
+    ))
+);
+fn is_gap_free_symbol(input: &str) -> NomResult<&str, String> {
+    alt((
+        verify(is_terminal_character, |o: &str| {
+            alt((is_first_quote_symbol, is_second_quote_symbol))(o).is_err()
+        })
+        .map(|d| format!("{}", d)),
+        is_terminal_string,
+    ))(input)
+}
+
+ebnf_characters_functions!(
+    is_terminal_string,
+    String,
+    alt((alt((
+        tuple((
+            is_first_quote_symbol,
+            is_first_terminal_character,
+            many0(is_first_terminal_character),
+            is_first_quote_symbol,
+        )),
+        tuple((
+            is_second_quote_symbol,
+            is_second_terminal_character,
+            many0(is_second_terminal_character),
+            is_second_quote_symbol,
+        )),
+    ))
+    .map(|(a, b, c, d)| format!("{}{}{}{}", a, b, c.join(""), d)),))
+);
+
+ebnf_characters_functions!(
+    is_first_terminal_character,
+    &str,
+    verify(is_terminal_character, |o| {
+        is_first_quote_symbol(o).is_err()
+    })
+);
+ebnf_characters_functions!(
+    is_second_terminal_character,
+    &str,
+    verify(is_terminal_character, |o| {
+        is_second_quote_symbol(o).is_err()
+    })
+);
+ebnf_characters_functions!(
+    is_gap_separator,
+    &str,
+    alt((
+        is_space_character,
+        is_horizontal_tabulation_character,
+        is_new_line,
+        is_vertical_tabulation_character,
+        is_form_feed
+    ))
+);
+ebnf_characters_functions!(
+    is_syntax,
+    String,
+    alt((tuple((
+        many0(is_gap_separator),
+        is_gap_free_symbol,
+        many0(is_gap_separator),
+        many0(tuple((is_gap_free_symbol, many0(is_gap_separator)))),
+    ))
+    .map(|(a, b, c, d)| {
+        format!(
+            "{}{}{}{}",
+            a.join(""),
+            b,
+            c.join(""),
+            d.iter()
+                .map(|(e, f)| format!("{}{}", e, f.join("")))
+                .collect::<String>()
+        )
+    }),))
+);
+
+// The third part of the syntax defines the removal of bracketed-textual-comments
+// from gap-free-symbols that form a syntax.
+
+ebnf_characters_functions!(
+    is_commentless_symbol,
+    String,
+    alt((
+        verify(is_terminal_character, |o| {
+            not(alt((
+                is_letter,
+                is_decimal_digit,
+                is_first_quote_symbol,
+                is_second_quote_symbol,
+                is_start_comment_symbol,
+                is_end_comment_symbol,
+                is_special_sequence_symbol,
+                is_other_character,
+            )))(o)
+            .is_err()
+        })
+        .map(|o| o.to_string()),
+        is_meta_identifier,
+        is_integer,
+        is_terminal_string,
+        is_special_sequence,
+    ))
+);
+
+fn is_integer(input: &str) -> NomResult<&str, String> {
+    tuple((is_decimal_digit, many0(is_decimal_digit)))
+        .map(|(a, b)| format!("{}{}", a, b.join("")))
+        .parse(input)
+}
+
+fn is_meta_identifier(input: &str) -> NomResult<&str, String> {
+    tuple((is_letter, many0(is_meta_identifier_character)))
+        .map(|(a, b)| format!("{}{}", a, b.join("")))
+        .parse(input)
+}
+
+ebnf_characters_functions!(
+    is_meta_identifier_character,
+    &str,
+    alt((is_letter, is_decimal_digit))
+);
+
+ebnf_characters_functions!(
+    is_special_sequence,
+    String,
+    alt((tuple((
+        is_special_sequence_symbol,
+        many0(is_special_sequence_character),
+        is_special_sequence_symbol,
+    ))
+    .map(|(a, b, c)| format!("{}{}{}", a, b.join(""), c)),))
+);
+
+ebnf_characters_functions!(
+    is_special_sequence_character,
+    &str,
+    verify(is_terminal_character, |o| {
+        is_special_sequence_symbol(o).is_err()
+    })
+);
+
+mod tests {
+    #[allow(unused_imports)]
+    use crate::parser::*;
+
+    #[test]
+    fn test_output_of_gap_free_symbol() {
+        assert_eq!(
+            is_gap_free_symbol("'hello'"),
+            Ok(("", "'hello'".to_string()))
+        );
+        assert_eq!(
+            is_gap_free_symbol("\"hello\""),
+            Ok(("", "\"hello\"".to_string()))
+        );
+        assert_eq!(is_gap_free_symbol("a"), Ok(("", "a".to_string())));
+        assert_eq!(is_gap_free_symbol("ab"), Ok(("b", "a".to_string())));
+        assert_eq!(
+            is_gap_free_symbol("hello world"),
+            Ok(("ello world", "h".to_string()))
+        );
+        assert_eq!(
+            is_gap_free_symbol("'hello world'"),
+            Ok(("", "'hello world'".to_string()))
+        );
+        assert_eq!(
+            is_gap_free_symbol("\"hello world\""),
+            Ok(("", "\"hello world\"".to_string()))
+        );
+        assert_eq!(
+            is_gap_free_symbol("'hello' world"),
+            Ok((" world", "'hello'".to_string()))
+        );
+        assert_eq!(
+            is_gap_free_symbol("\"hello\" world"),
+            Ok((" world", "\"hello\"".to_string()))
+        );
+        assert!(is_gap_free_symbol("\n").is_err());
     }
-}
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct MetaIdentifier(String);
-
-impl_from_str!(MetaIdentifier, Rule::meta_identifier);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for MetaIdentifier {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<MetaIdentifier> {
-        match pair.as_rule() {
-            Rule::meta_identifier => Ok(MetaIdentifier(String::from(pair.as_str()))),
-            o => Err(EBNFError::UnexpectedRules(vec![(
-                o,
-                pair.as_str().to_string(),
-            )])),
-        }
+    #[test]
+    fn test_output_of_terminal_string() {
+        assert!(is_terminal_string("'hello'").is_ok());
+        assert!(is_terminal_string("\"world\"").is_ok());
     }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct SyntaxRule {
-    identifier: MetaIdentifier,
-    definitions: DefinitionList,
-}
-
-impl_from_str!(SyntaxRule, Rule::syntax_rule);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SyntaxRule {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SyntaxRule> {
-        let mut pair = pair.into_inner();
-        match (pair.next(), pair.next(), pair.next(), pair.next()) {
-            (
-                Some(meta_identifier),
-                Some(defining_symbol),
-                Some(definition_list),
-                Some(terminator_symbol),
-            ) => match (
-                meta_identifier.as_rule(),
-                defining_symbol.as_rule(),
-                definition_list.as_rule(),
-                terminator_symbol.as_rule(),
-            ) {
-                (
-                    Rule::meta_identifier,
-                    Rule::defining_symbol,
-                    Rule::definition_list,
-                    Rule::terminator_symbol,
-                ) => Ok(SyntaxRule {
-                    identifier: MetaIdentifier::try_from(meta_identifier)?,
-                    definitions: DefinitionList::try_from(definition_list)?,
-                }),
-                (a, b, c, d) => Err(EBNFError::UnexpectedRules(vec![
-                    (a, meta_identifier.as_str().to_string()),
-                    (b, defining_symbol.as_str().to_string()),
-                    (c, definition_list.as_str().to_string()),
-                    (d, terminator_symbol.as_str().to_string()),
-                ])),
-            },
-            (a, b, c, d) => Err(EBNFError::InsufficientTokens(vec![
-                a.map(|p| p.as_rule()),
-                b.map(|p| p.as_rule()),
-                c.map(|p| p.as_rule()),
-                d.map(|p| p.as_rule()),
-            ])),
-        }
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct DefinitionList(Vec<SingleDefinition>);
-
-impl_from_str!(DefinitionList, Rule::definition_list);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for DefinitionList {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<DefinitionList> {
-        let pair = pair.into_inner();
-        Ok(DefinitionList(
-            pair.step_by(2)
-                .map(SingleDefinition::try_from)
-                .collect::<EBNFResult<Vec<SingleDefinition>>>()?,
-        ))
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct SingleDefinition(Vec<SyntacticTerm>);
-
-impl_from_str!(SingleDefinition, Rule::single_definition);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SingleDefinition {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SingleDefinition> {
-        let pair = pair.into_inner();
-        Ok(SingleDefinition(
-            pair.step_by(2)
-                .map(SyntacticTerm::try_from)
-                .collect::<EBNFResult<Vec<SyntacticTerm>>>()?,
-        ))
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct SyntacticException(String);
-
-impl_from_str!(SyntacticException, Rule::syntactic_exception);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticException {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SyntacticException> {
-        let pair = pair.into_inner();
-        Ok(SyntacticException(String::from(pair.as_str())))
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct SyntacticTerm {
-    factor: SyntacticFactor,
-    except: Option<SyntacticException>,
-}
-
-impl_from_str!(SyntacticTerm, Rule::syntactic_term);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticTerm {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SyntacticTerm> {
-        let mut pair = pair.into_inner();
-        match (pair.next(), pair.next(), pair.next()) {
-            (Some(syntactic_factor), Some(except_symbol), Some(syntactic_exception)) => match (
-                syntactic_factor.as_rule(),
-                except_symbol.as_rule(),
-                syntactic_exception.as_rule(),
-            ) {
-                (Rule::syntactic_factor, Rule::except_symbol, Rule::syntactic_exception) => {
-                    Ok(SyntacticTerm {
-                        factor: SyntacticFactor::try_from(syntactic_factor)?,
-                        // NOTE: If we are this far, failure to obtain a syntactic_exception is not equivalent to it not existing.
-                        except: SyntacticException::try_from(syntactic_exception).ok(),
-                    })
-                }
-                (a, b, c) => Err(EBNFError::UnexpectedRules(vec![
-                    (a, syntactic_factor.as_str().to_string()),
-                    (b, except_symbol.as_str().to_string()),
-                    (c, syntactic_exception.as_str().to_string()),
-                ])),
-            },
-            (Some(syntactic_factor), None, None) => Ok(SyntacticTerm {
-                factor: SyntacticFactor::try_from(syntactic_factor)?,
-                except: None,
-            }),
-            (a, b, c) => Err(EBNFError::InsufficientTokens(vec![
-                a.map(|p| p.as_rule()),
-                b.map(|p| p.as_rule()),
-                c.map(|p| p.as_rule()),
-            ])),
-        }
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub struct SyntacticFactor {
-    repetition: usize,
-    primary: SyntacticPrimary,
-}
-
-impl_from_str!(SyntacticFactor, Rule::syntactic_factor);
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticFactor {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SyntacticFactor> {
-        let mut pair = pair.into_inner();
-        match (pair.next(), pair.next(), pair.next()) {
-            (Some(integer), Some(repetition_symbol), Some(syntactic_primary)) => match (
-                integer.as_rule(),
-                repetition_symbol.as_rule(),
-                syntactic_primary.as_rule(),
-            ) {
-                (Rule::integer, Rule::repetition_symbol, Rule::syntactic_primary) => {
-                    Ok(SyntacticFactor {
-                        // can unwrap here because the grammar already ensures this is a number
-                        repetition: integer.as_str().parse::<usize>().unwrap(),
-                        primary: SyntacticPrimary::try_from(syntactic_primary)?,
-                    })
-                }
-                (a, b, c) => Err(EBNFError::UnexpectedRules(vec![
-                    (a, integer.as_str().to_string()),
-                    (b, repetition_symbol.as_str().to_string()),
-                    (c, syntactic_primary.as_str().to_string()),
-                ])),
-            },
-            (Some(syntactic_primary), None, None) => match syntactic_primary.as_rule() {
-                Rule::syntactic_primary => Ok(SyntacticFactor {
-                    repetition: 1,
-                    primary: SyntacticPrimary::try_from(syntactic_primary)?,
-                }),
-                o => Err(EBNFError::UnexpectedRules(vec![(
-                    o,
-                    syntactic_primary.as_str().to_string(),
-                )])),
-            },
-            (a, b, c) => Err(EBNFError::InsufficientTokens(vec![
-                a.map(|p| p.as_rule()),
-                b.map(|p| p.as_rule()),
-                c.map(|p| p.as_rule()),
-            ])),
-        }
-    }
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub enum SyntacticPrimary {
-    Optional(DefinitionList),
-    Repeated(DefinitionList),
-    Grouped(DefinitionList),
-    // By definition, we have no idea how to parse special sequences.
-    // just pass the string to the user.
-    Special(String),
-    MetaIdentifier(String),
-    TerminalString(String),
-}
-
-impl_from_str!(SyntacticPrimary, Rule::syntactic_primary);
-
-impl SyntacticPrimary {
-    fn parse_definition_list_in_sequence(
-        mut pair: Pairs<Rule>,
-        sequence_begin_symbol: Rule,
-        sequence_end_symbol: Rule,
-    ) -> EBNFResult<DefinitionList> {
-        match (pair.next(), pair.next(), pair.next()) {
-            (Some(start_repeat_symbol), Some(definition_list), Some(end_repeat_symbol)) => {
-                match (
-                    start_repeat_symbol.as_rule(),
-                    definition_list.as_rule(),
-                    end_repeat_symbol.as_rule(),
-                ) {
-                    (begin_symbol, Rule::definition_list, end_symbol) => {
-                        if begin_symbol == sequence_begin_symbol
-                            && end_symbol == sequence_end_symbol
-                        {
-                            Ok(DefinitionList::try_from(definition_list)?)
-                        } else {
-                            Err(EBNFError::UnexpectedRules(vec![
-                                (begin_symbol, start_repeat_symbol.as_str().to_string()),
-                                (Rule::definition_list, definition_list.as_str().to_string()),
-                                (end_symbol, end_repeat_symbol.as_str().to_string()),
-                            ]))
-                        }
-                    }
-                    (a, b, c) => Err(EBNFError::UnexpectedRules(vec![
-                        (a, start_repeat_symbol.as_str().to_string()),
-                        (b, definition_list.as_str().to_string()),
-                        (c, end_repeat_symbol.as_str().to_string()),
-                    ])),
-                }
-            }
-            (a, b, c) => Err(EBNFError::InsufficientTokens(vec![
-                a.map(|p| p.as_rule()),
-                b.map(|p| p.as_rule()),
-                c.map(|p| p.as_rule()),
-            ])),
-        }
-    }
-}
-
-impl<'r> TryFrom<Pair<'r, Rule>> for SyntacticPrimary {
-    type Error = EBNFError;
-    fn try_from(pair: Pair<Rule>) -> EBNFResult<SyntacticPrimary> {
-        let mut pair = pair.into_inner();
-        match pair.next() {
-            Some(pair) => match pair.as_rule() {
-                Rule::optional_sequence => {
-                    let pair = pair.into_inner();
-                    Ok(SyntacticPrimary::Optional(
-                        SyntacticPrimary::parse_definition_list_in_sequence(
-                            pair,
-                            Rule::start_option_symbol,
-                            Rule::end_option_symbol,
-                        )?,
-                    ))
-                }
-                Rule::repeated_sequence => {
-                    let pair = pair.into_inner();
-                    Ok(SyntacticPrimary::Repeated(
-                        SyntacticPrimary::parse_definition_list_in_sequence(
-                            pair,
-                            Rule::start_repeat_symbol,
-                            Rule::end_repeat_symbol,
-                        )?,
-                    ))
-                }
-                Rule::grouped_sequence => {
-                    let pair = pair.into_inner();
-                    Ok(SyntacticPrimary::Grouped(
-                        SyntacticPrimary::parse_definition_list_in_sequence(
-                            pair,
-                            Rule::start_group_symbol,
-                            Rule::end_group_symbol,
-                        )?,
-                    ))
-                }
-                Rule::meta_identifier => Ok(SyntacticPrimary::MetaIdentifier(
-                    MetaIdentifier::try_from(pair)?.0,
-                )),
-                Rule::terminal_string => Ok(SyntacticPrimary::TerminalString(String::from(
-                    pair.as_str(),
-                ))),
-                Rule::special_sequence => {
-                    Ok(SyntacticPrimary::Special(String::from(pair.as_str())))
-                }
-                o => Err(EBNFError::UnexpectedRules(vec![(
-                    o,
-                    pair.as_str().to_string(),
-                )])),
-            },
-            None => Err(EBNFError::NoTokens),
-        }
-    }
-}
-
-#[test]
-fn parse_meta_identifier() {
-    let pair = InnerParser::parse(Rule::meta_identifier, r#"letter"#)
-        .unwrap()
-        .next()
-        .unwrap();
-    assert_eq!(
-        MetaIdentifier::try_from(pair).unwrap(),
-        MetaIdentifier("letter".to_string())
-    );
-}
-
-#[test]
-fn parse_symbols() {
-    InnerParser::parse(Rule::defining_symbol, r#"="#).unwrap();
-    InnerParser::parse(Rule::definition_separator_symbol, r#"|"#).unwrap();
-    InnerParser::parse(Rule::first_quote_symbol, r#"'"#).unwrap();
-    InnerParser::parse(Rule::second_quote_symbol, r#"""#).unwrap();
-    InnerParser::parse(Rule::repetition_symbol, r#"*"#).unwrap();
-}
-
-#[test]
-fn parse_terminal_string() {
-    InnerParser::parse(Rule::terminal_string, r#""b \r a \n d""#).unwrap();
-    InnerParser::parse(Rule::terminal_string, r#"'a'"#).unwrap();
-}
-
-#[test]
-fn parse_syntactic_factor() {
-    let pair = InnerParser::parse(Rule::syntactic_factor, r#"5 * {"abcde"}"#)
-        .unwrap()
-        .next()
-        .unwrap();
-    assert_eq!(
-        SyntacticFactor::try_from(pair).unwrap(),
-        SyntacticFactor {
-            repetition: 5,
-            primary: SyntacticPrimary::Repeated(DefinitionList(vec![SingleDefinition(vec![
-                SyntacticTerm {
-                    factor: SyntacticFactor {
-                        repetition: 1,
-                        primary: SyntacticPrimary::TerminalString(r#""abcde""#.to_string())
-                    },
-                    except: None
-                }
-            ])]))
-        }
-    );
-}
-
-#[test]
-fn parse_syntactic_term() {
-    let pair = InnerParser::parse(Rule::syntactic_term, r#"{"abcde"} - "xyz""#)
-        .unwrap()
-        .next()
-        .unwrap();
-    assert_eq!(
-        SyntacticTerm::try_from(pair).unwrap(),
-        SyntacticTerm {
-            factor: SyntacticFactor {
-                repetition: 1,
-                primary: SyntacticPrimary::Repeated(DefinitionList(vec![SingleDefinition(vec![
-                    SyntacticTerm {
-                        factor: SyntacticFactor {
-                            repetition: 1,
-                            primary: SyntacticPrimary::TerminalString(r#""abcde""#.to_string())
-                        },
-                        except: None
-                    }
-                ])]))
-            },
-            except: Some(SyntacticException(r#""xyz""#.to_string()))
-        }
-    );
-}
-
-#[test]
-fn parse_definition_list() {
-    let pair = InnerParser::parse(
-        Rule::definition_list,
-        r#"(5 * {"abcde"} - "xyz") | "fghi", "ghi";"#,
-    )
-    .unwrap()
-    .next()
-    .unwrap();
-    assert_eq!(
-        DefinitionList::try_from(pair).unwrap(),
-        DefinitionList(vec![
-            SingleDefinition(vec![SyntacticTerm {
-                factor: SyntacticFactor {
-                    repetition: 1,
-                    primary: SyntacticPrimary::Grouped(DefinitionList(vec![SingleDefinition(
-                        vec![SyntacticTerm {
-                            factor: SyntacticFactor {
-                                repetition: 5,
-                                primary: SyntacticPrimary::Repeated(DefinitionList(vec![
-                                    SingleDefinition(vec![SyntacticTerm {
-                                        factor: SyntacticFactor {
-                                            repetition: 1,
-                                            primary: SyntacticPrimary::TerminalString(
-                                                "\"abcde\"".to_string()
-                                            )
-                                        },
-                                        except: None
-                                    }])
-                                ]))
-                            },
-                            except: Some(SyntacticException("\"xyz\"".to_string()))
-                        }]
-                    )]))
-                },
-                except: None
-            }]),
-            SingleDefinition(vec![
-                SyntacticTerm {
-                    factor: SyntacticFactor {
-                        repetition: 1,
-                        primary: SyntacticPrimary::TerminalString("\"fghi\"".to_string())
-                    },
-                    except: None
-                },
-                SyntacticTerm {
-                    factor: SyntacticFactor {
-                        repetition: 1,
-                        primary: SyntacticPrimary::TerminalString("\"ghi\"".to_string())
-                    },
-                    except: None
-                }
-            ])
-        ])
-    );
-}
-
-#[test]
-fn parse_syntax_rule() {
-    let pair = InnerParser::parse(Rule::syntax_rule, r#"letter = "a" | "b";"#)
-        .unwrap()
-        .next()
-        .unwrap();
-    assert_eq!(
-        SyntaxRule::try_from(pair).unwrap(),
-        SyntaxRule {
-            identifier: MetaIdentifier("letter".to_string()),
-            definitions: DefinitionList::try_from(
-                InnerParser::parse(Rule::definition_list, r#""a" | "b""#)
-                    .unwrap()
-                    .next()
-                    .unwrap()
-            )
-            .unwrap()
-        }
-    );
-    let pair = InnerParser::parse(
-        Rule::syntax,
-        r#"
-        (* comment *) letter (* comment *)
-        = (* comment *) "a" (* comment *) | (* comment *) "b" (* comment *) ;"#,
-    )
-    .unwrap()
-    .next()
-    .unwrap();
-    assert_eq!(
-        Syntax::try_from(pair).unwrap(),
-        Syntax {
-            rules: vec![SyntaxRule {
-                identifier: MetaIdentifier("letter".to_string()),
-                definitions: DefinitionList::try_from(
-                    InnerParser::parse(Rule::definition_list, r#""a" | "b""#)
-                        .unwrap()
-                        .next()
-                        .unwrap()
-                )
-                .unwrap()
-            }]
-        }
-    );
-}
-
-#[test]
-fn parse_ebnf_itself() {
-    let _ = InnerParser::parse(
-        Rule::syntax,
-        r##"
-(*
-The syntax of Extended BNF can be defined using
-itself. There are four parts in this example,
-the first part names the characters, the second
-part defines the removal of unnecessary nonprinting characters, the third part defines the
-removal of textual comments, and the final part
-defines the structure of Extended BNF itself.
-Each syntax rule in this example starts with a
-comment that identifies the corresponding clause
-in the standard.
-The meaning of special-sequences is not defined
-in the standard. In this example (see the
-reference to 7.6) they represent control
-functions defined by ISO/IEC 6429:1992.
-Another special-sequence defines a
-syntactic-exception (see the reference to 4.7).
-*)
-(*
-The first part of the lexical syntax defines the
-characters in the 7-bit character set (ISO/IEC
-646:1991) that represent each terminal-character
-and gap-separator in Extended BNF.
-*)
-(* see 7.2 *)
-letter = 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'
-| 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p'
-| 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x'
-| 'y' | 'z'
-| 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H'
-| 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P'
-| 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X'
-| 'Y' | 'Z';
-(* see 7.2 *) decimal_digit
-= '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7'
-| '8' | '9';
-(*
-The representation of the following
-terminal-characters is defined in clauses 7.3,
-7.4 and tables 1, 2.
-*)
-concatenate_symbol = ',';
-defining_symbol = '=';
-definition_separator_symbol = '|' | '//' | '!';
-end_comment_symbol = '*)';
-end_group_symbol = ')';
-end_option_symbol = ']' | '/)';
-end_repeat_symbol = '}' | ':)';
-except_symbol = '-';
-first_quote_symbol = "'";
-repetition_symbol = '*';
-second_quote_symbol = '"';
-special_sequence_symbol = '?';
-start_comment_symbol = '(*';
-start_group_symbol = '(';
-start_option_symbol = '[' | '(//';
-start_repeat_symbol = '{' | '(:';
-terminator_symbol = ';' | '.';
-(* see 7.5 *) other_character
-= ' ' | ':' | '+' | '_' | '%' | '@'
-| '&' | '#' | '$' | '<' | '>' | '\'
-| 'ˆ' | '‘' | '~';
-(* see 7.6 *) space_character = ' ';
-                "##,
-    )
-    .unwrap()
-    .next()
-    .unwrap();
 }

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -1,11 +1,1 @@
-#[test]
-pub fn use_syntax_to_validate() {
-    let syntax = iso_14977::parse(
-        r#"
-    digit excluding zero = "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
-    digit                = "0" | digit excluding zero ;
-    natural number       = digit excluding zero, { digit } ;"#,
-    )
-    .unwrap();
-    println!("{:#?}", syntax);
-}
+


### PR DESCRIPTION
`pest` still cause issues for rust-analyzer giving annoying false-negative.
Reimplement the entire gosh darned thing using nom instead.

Signed-off-by: Hanif Ariffin <hanif.ariffin.4326@gmail.com>